### PR TITLE
consenTRAIT function now works; still generating errors though

### DIFF
--- a/phylo/phylo.long_V2.Rmd
+++ b/phylo/phylo.long_V2.Rmd
@@ -373,14 +373,11 @@ ConsenTrait <- function(tree = "", traits = "", cutoff = 0.9,
   return(data.out)
 }
 
-ConsenTrait <- function(tree = "", traits = "", cutoff = 0.9,
-                        status = TRUE){
-ConsenTrait(ml.rooted,traits$b)
-d
-d```
+ConsenTrait(tree = ml.rooted, traits = log.alpha)
+```
 
 
-### C. Correlations of alpha, beta, and hafl with other traits
+### C. Correlations of alpha, beta, and half-life with other traits
 
 ```{r}
 # Log transform initial death, which spans > 4 orders of magnitude


### PR DESCRIPTION
getting error re: incorrect number of dimensions, even though they (traits and tree) seem to match up:

> ConsenTrait(tree = ml.rooted, traits = log.alpha)
Error in table[, 1] : incorrect number of dimensions
In addition: Warning messages:
1: Unknown column 'Trait' 
2: Unknown column 'Trait' 
3: Unknown column 'Trait' 
4: Unknown column 'Trait' 
5: Unknown column 'Trait' 
6: Unknown column 'Trait' 
Called from: match(x, table, nomatch = 0L)
Browse[1]> Q